### PR TITLE
♻️ market stats are now only served

### DIFF
--- a/src/Entity/GenerativeToken.ts
+++ b/src/Entity/GenerativeToken.ts
@@ -6,6 +6,7 @@ import { Entity, Column, PrimaryColumn, UpdateDateColumn, BaseEntity, CreateDate
 import { GenerativeTokenMetadata } from '../types/Metadata'
 import { Action } from './Action'
 import { MarketStats } from './MarketStats'
+import { MarketStatsHistory } from './MarketStatsHistory'
 import { Objkt } from './Objkt'
 import { Report } from './Report'
 import { DateTransformer } from './Transformers/DateTransformer'
@@ -124,6 +125,9 @@ export class GenerativeToken extends BaseEntity {
   @OneToOne(() => MarketStats, stats => stats.token)
   marketStats: MarketStats
 
+  @OneToMany(() => MarketStatsHistory, stats => stats.token)
+  marketStatsHistory: MarketStatsHistory
+
   @Field()
   @CreateDateColumn({ type: 'timestamptz', transformer: DateTransformer })
   createdAt: string
@@ -137,41 +141,6 @@ export class GenerativeToken extends BaseEntity {
 
   @Field(type => [Objkt], { nullable: true })
   offers: Objkt[]
-
-  static async findOrCreate(id: number, createdAt: string): Promise<GenerativeToken> {
-    let token = await GenerativeToken.findOne(id)
-    if (!token) {
-      token = GenerativeToken.create({ id, createdAt })
-    }
-    return token
-  }
-
-  /**
-   * Given a name, sets the slug on the entity (ensures that no other entity has the same slug)
-   */
-   async setSlugFromName(name: string) {
-    let appendix: number|null = null
-    while(true) {
-      let slug = slugify(`${name} ${appendix!==null?appendix:""}`, {
-        lower: true
-      })
-
-      // do we have an Entity with this slug already ?
-      const found = await GenerativeToken.findOne({
-        where: {
-          slug
-        }
-      })
-      if (found) {
-        appendix = appendix === null ? 1 : appendix+1
-        continue
-      }
-      else {
-        this.slug = slug
-        break
-      }
-    }
-  }
 
   //
   // FILTERS FOR THE GQL ENDPOINT

--- a/src/Entity/MarketStatsHistory.ts
+++ b/src/Entity/MarketStatsHistory.ts
@@ -1,23 +1,19 @@
 import { Field, ObjectType } from 'type-graphql'
-import { Entity, Column, PrimaryColumn, UpdateDateColumn, BaseEntity, OneToOne, JoinColumn, RelationId } from 'typeorm'
+import { Entity, Column, UpdateDateColumn, BaseEntity, ManyToOne, Index, PrimaryGeneratedColumn } from 'typeorm'
 import { GenerativeToken } from './GenerativeToken'
-import { DateTransformer } from './Transformers/DateTransformer'
 
-@Entity()
 @ObjectType()
-export class MarketStats extends BaseEntity {
-  @PrimaryColumn()
+@Entity()
+export class MarketStatsHistory extends BaseEntity {
+  @PrimaryGeneratedColumn()
   id: number
 
-  @OneToOne(() => GenerativeToken)
-  @JoinColumn()
+  @ManyToOne(() => GenerativeToken, token => token.marketStatsHistory, { onDelete: "CASCADE" })
   token: GenerativeToken
 
-  @RelationId((stats: MarketStats) => stats.token)
-	tokenId: number
-
-  @Column({ default: false })
-  requiresUpdate: boolean
+  @Index()
+  @Column()
+  tokenId: number
 
   @Field(type => Number, { nullable: true })
   @Column({ type: "bigint", nullable: true })
@@ -41,41 +37,29 @@ export class MarketStats extends BaseEntity {
   
   @Field(type => Number, { nullable: true })
   @Column({ type: "bigint", nullable: true })
-  primVolumeNb: number|null
-  
-  @Field(type => Number, { nullable: true })
-  @Column({ type: "bigint", nullable: true })
   primVolumeTz: number|null
   
   @Field(type => Number, { nullable: true })
   @Column({ type: "bigint", nullable: true })
+  primVolumeNb: number|null
+  
+  // the volume (tezos) on the covered period
+  @Field(type => Number, { nullable: true })
+  @Column({ type: "bigint", nullable: true })
 	secVolumeTz: number|null
   
+  // the volume (number) on the covered period
   @Field(type => Number, { nullable: true })
   @Column({ type: "bigint", nullable: true })
 	secVolumeNb: number|null
   
-  @Field(type => Number, { nullable: true })
-  @Column({ type: "bigint", nullable: true })
-	secVolumeTz24: number|null
+  // [from; to] defines the range covered by those stats
   
-  @Field(type => Number, { nullable: true })
-  @Column({ type: "bigint", nullable: true })
-	secVolumeNb24: number|null
-  
-  @Field(type => Number, { nullable: true })
-  @Column({ type: "bigint", nullable: true })
-	secVolumeTz7d: number|null
-  
-  @Field(type => Number, { nullable: true })
-  @Column({ type: "bigint", nullable: true })
-	secVolumeNb7d: number|null
-
-  @Field()
-  @Column({ type: "timestamptz" })
+  @Field({ nullable: true })
+  @UpdateDateColumn({ type: "timestamptz" })
   from: Date
-
-  @Field()
-  @Column({ type: "timestamptz" })
+  
+  @Field({ nullable: true })
+  @UpdateDateColumn({ type: "timestamptz" })
   to: Date
 }

--- a/src/Entity/Objkt.ts
+++ b/src/Entity/Objkt.ts
@@ -97,41 +97,6 @@ export class Objkt extends BaseEntity {
   @Column({ type: "timestamptz", transformer: DateTransformer })
   @Filter(["gt", "lt"])
   assignedAt: string
-
-  static async findOrCreate(id: number, createdAt: string): Promise<Objkt> {
-    let objkt = await Objkt.findOne(id, { relations: [ "owner", "issuer" ]})
-    if (!objkt) {
-      objkt = Objkt.create({ id, createdAt })
-    }
-    return objkt
-  }
-
-  /**
-   * Given a name, sets the slug on the entity (ensures that no other entity has the same slug)
-   */
-   async setSlugFromName(name: string) {
-    let appendix: number|null = null
-    while(true) {
-      let slug = slugify(`${name} ${appendix!==null?appendix:""}`, {
-        lower: true
-      })
-
-      // do we have an Entity with this slug already ?
-      const found = await Objkt.findOne({
-        where: {
-          slug
-        }
-      })
-      if (found) {
-        appendix = appendix === null ? 1 : appendix+1
-        continue
-      }
-      else {
-        this.slug = slug
-        break
-      }
-    }
-  }
 }
 
 // the Type for the filters of the GraphQL query for Objkt

--- a/src/Entity/User.ts
+++ b/src/Entity/User.ts
@@ -102,12 +102,4 @@ export class User extends BaseEntity {
   @Field()
   @Column({ type: "timestamptz", transformer: DateTransformer })
   updatedAt: string
-
-  static async findOrCreate(id: string, createdAt: string): Promise<User> {
-    let user = await User.findOne(id)
-    if (!user) {
-      user = User.create({ id, createdAt, updatedAt: createdAt })
-    }
-    return user
-  }
 }

--- a/src/Resolver/GenTokeenResolver.ts
+++ b/src/Resolver/GenTokeenResolver.ts
@@ -4,6 +4,7 @@ import { Equal, In, LessThanOrEqual, MoreThan } from "typeorm"
 import { Action, FiltersAction } from "../Entity/Action"
 import { GenerativeFilters, GenerativeToken, GenTokFlag } from "../Entity/GenerativeToken"
 import { MarketStats } from "../Entity/MarketStats"
+import { MarketStatsHistory } from "../Entity/MarketStatsHistory"
 import { FiltersObjkt, Objkt } from "../Entity/Objkt"
 import { Report } from "../Entity/Report"
 import { User } from "../Entity/User"
@@ -116,7 +117,7 @@ export class GenTokenResolver {
 		})
 	}
 
-	@FieldResolver(returns => MarketStats)
+	@FieldResolver(returns => MarketStats, { nullable: true })
 	async marketStats(
 		@Root() token: GenerativeToken,
 		@Ctx() ctx: RequestContext
@@ -124,6 +125,14 @@ export class GenTokenResolver {
 		if (token.marketStats) return token.marketStats
 		return ctx.genTokMarketStatsLoader.load(token.id)
 	}
+		
+	@FieldResolver(returns => [MarketStatsHistory])
+	async marketStatsHistory(	
+		@Root() token: GenerativeToken,
+		@Ctx() ctx: RequestContext
+	) {
+		return ctx.genTokMarketStatsHistoryLoader.load(token.id)
+	} 
   
   @Query(returns => [GenerativeToken])
 	async generativeTokens(

--- a/src/Utils/Context.ts
+++ b/src/Utils/Context.ts
@@ -1,4 +1,4 @@
-import { createGenTokActionsLoader, createGenTokLatestActionsLoader, createGenTokLatestObjktsLoader, createGenTokLoader, createGenTokMarketStatsLoader, createGenTokObjktsCountLoader, createGenTokObjktsLoader, createGenTokReportsLoader } from '../DataLoaders/GenTokens'
+import { createGenTokActionsLoader, createGenTokLatestActionsLoader, createGenTokLatestObjktsLoader, createGenTokLoader, createGenTokMarketStatsHistoryLoader, createGenTokMarketStatsLoader, createGenTokObjktsCountLoader, createGenTokObjktsLoader, createGenTokReportsLoader } from '../DataLoaders/GenTokens'
 import { createObjktActionsLoader, createObjktGenerativesLoader, createObjktOffersLoader, createObjktOwnersLoader, createObjktsLoader } from '../DataLoaders/Objkt'
 import { createOfferIssuersLoader, createOfferObjktsLoader, createOffersLoader } from '../DataLoaders/Offer'
 import { createUsersGenTokLoader, createUsersIssuerActionssLoader, createUsersLoader, createUsersObjktLoader, 
@@ -31,6 +31,7 @@ export const createContext = (req: any, res: any): RequestContext => {
 		genTokReportsLoader: createGenTokReportsLoader(),
 		genTokMarketStatsLoader: createGenTokMarketStatsLoader(),
 		genTokObjktsCountLoader: createGenTokObjktsCountLoader(),
+		genTokMarketStatsHistoryLoader: createGenTokMarketStatsHistoryLoader(),
 
     // OFFERS loaders
     offersLoader: createOffersLoader(),

--- a/src/types/RequestContext.ts
+++ b/src/types/RequestContext.ts
@@ -1,5 +1,5 @@
 import { Request as ExpressRequest } from "express"
-import { createGenTokActionsLoader, createGenTokLatestActionsLoader, createGenTokLatestObjktsLoader, createGenTokLoader, createGenTokMarketStatsLoader, createGenTokObjktsCountLoader, createGenTokObjktsLoader, createGenTokReportsLoader } from "../DataLoaders/GenTokens"
+import { createGenTokActionsLoader, createGenTokLatestActionsLoader, createGenTokLatestObjktsLoader, createGenTokLoader, createGenTokMarketStatsHistoryLoader, createGenTokMarketStatsLoader, createGenTokObjktsCountLoader, createGenTokObjktsLoader, createGenTokReportsLoader } from "../DataLoaders/GenTokens"
 import { createObjktActionsLoader, createObjktGenerativesLoader, createObjktOffersLoader, createObjktOwnersLoader, createObjktsLoader } from "../DataLoaders/Objkt"
 import { createOfferIssuersLoader, createOfferObjktsLoader, createOffersLoader } from "../DataLoaders/Offer"
 import { createUsersObjktLoader, createUsersGenTokLoader, createUsersOffersLoader, createUsersIssuerActionssLoader, 
@@ -34,6 +34,7 @@ export interface RequestContext extends ExpressRequest {
   genTokReportsLoader: ReturnType<typeof createGenTokReportsLoader>,
   genTokMarketStatsLoader: ReturnType<typeof createGenTokMarketStatsLoader>,
   genTokObjktsCountLoader: ReturnType<typeof createGenTokObjktsCountLoader>,
+  genTokMarketStatsHistoryLoader: ReturnType<typeof createGenTokMarketStatsHistoryLoader>,
 
   // OFFERS loaders
   offersLoader: ReturnType<typeof createOffersLoader>,


### PR DESCRIPTION
The computation of the marketplace stats is now handled in a separate worker.
From now on, the API will only serve those pre-computed stats, which should boost the performances of the endpoint marketStats which had become a bottleneck for the whole API.
Introduction of the marketStatHistory

resolves:
* https://github.com/fxhash/fxhash-api/issues/5