### PR TITLE
Add objktsByIds

### DIFF
--- a/src/Resolver/ObjktResolver.ts
+++ b/src/Resolver/ObjktResolver.ts
@@ -2,6 +2,7 @@ import { Arg, Args, Ctx, FieldResolver, Query, Resolver, Root } from "type-graph
 import { Action } from "../Entity/Action"
 import { GenerativeToken } from "../Entity/GenerativeToken"
 import { FiltersObjkt, Objkt } from "../Entity/Objkt"
+import { In } from "typeorm"
 import { Offer } from "../Entity/Offer"
 import { User } from "../Entity/User"
 import { RequestContext } from "../types/RequestContext"
@@ -61,6 +62,20 @@ export class ObjktResolver {
 			take,
 			// cache: 10000
 		})
+	}
+
+	@Query((returns) => [Objkt], { nullable: true })
+	async objktsByIds(
+		@Arg("ids", (type) => [Number]) ids: number[]
+	): Promise<Objkt[]> {
+		const objkts = await Objkt.find({
+			where: [{
+				id: In(ids),
+			}],
+			take: 100,
+		});
+		// @ts-ignore
+		return ids.map((id) => objkts.find((o) => o.id == id)).filter((o) => !!o);
 	}
 
 	@Query(returns => Objkt, { nullable: true })


### PR DESCRIPTION
### Description

This PR adds a query for getting a list of `Objkt`s by `id`. This works exactly the same as the `generativeTokensByIds` query.

This functionality is useful for displaying a list of `Objkt`s on a page that are not necessarily related to the same `GenerativeToken`.

### How to Test

Run this query in the GraphQL sandbox:
```
query {
  objktsByIds(ids: [61387, 61427]) {
    id
    name
    issuer {
      name
    }
  }
}

```
