### PR TITLE
Require inner join on offer if sorting by offer

### DIFF
--- a/src/DataLoaders/GenTokens.ts
+++ b/src/DataLoaders/GenTokens.ts
@@ -40,9 +40,13 @@ const batchGenTokObjkt = async (genIds) => {
 		.select()
 		.where("objkt.issuerId IN (:...issuers)", { issuers: ids })
 
+	// offerPrice and offerCreatedAt sort requires a join to offer table
+	const sortRequiresOffer = sorts.includes(
+		(sort) => sort == "offerPrice" || sort == "offerCreatedAt"
+	);
 	// if the filters says "OFFER NOT NULL", we can use inner join to filter query
-	if (filters && filters.offer_ne === null) {
-		query = query.innerJoinAndSelect("objkt.offer", "offer")
+	if (sortRequiresOffer || (filters && filters.offer_ne === null)) {
+		query = query.innerJoinAndSelect("objkt.offer", "offer");
 	}
 
 	// add sorting


### PR DESCRIPTION
This PR proposes a change to the API that will automatically join the offer table when trying to sort `Objkt` by `offerPrice` or `offerCreatedAt`.

If the offer table isn't included then trying to use either of those sort options fails and throws a cryptic. It was not immediately clear that you needed to include a filter along with these sort options.

This change should allow this to work (which fails in production):
```
query {
  generativeToken(id: 20) {
    name
    id
    objkts(sort: {offerCreatedAt: "ASC"}) {
      name
    }
  }
}
```

Note:
- I had difficulty getting these changes to appear in my development environment for additional testing. 