### PR TITLE
Add artifactUri, thumbnailUri, and displayUri to top level of Objkt

### DIFF
--- a/src/Entity/Objkt.ts
+++ b/src/Entity/Objkt.ts
@@ -103,6 +103,29 @@ export class Objkt extends BaseEntity {
   @Column({ nullable: true })
   metadataUri: string
 
+  @Field({
+    nullable: true,
+    description:
+      "IPFS uri pointing to the web page hosting the Generator code.",
+  })
+  @Column({ nullable: true })
+  artifactUri?: string;
+
+  @Field({
+    nullable: true,
+    description:
+      "IPFS uri pointing to the 300x300 (contained) thumbnail of the gentk",
+  })
+  @Column({ nullable: true })
+  thumbnailUri?: string;
+
+  @Field({
+    nullable: true,
+    description: "IPFS uri pointing to the full res image of the gentk",
+  })
+  @Column({ nullable: true })
+  displayUri?: string;
+
   @Field(() => [String], {
     nullable: true,
     description: "A list of tags, set by the author(s) at mint time. Corresponds the the Generative Token tags."

--- a/src/Resolver/ObjktResolver.ts
+++ b/src/Resolver/ObjktResolver.ts
@@ -47,6 +47,30 @@ export class ObjktResolver {
 		return ctx.genTokLoader.load(objkt.issuerId)
 	}
 
+	@FieldResolver((returns) => String, {
+		description: "IPFS uri pointing to the web page hosting the Generator code.",
+	})
+	artifactUri(@Root() objkt: Objkt, @Ctx() ctx: RequestContext) {
+		if (objkt.artifactUri) return objkt.artifactUri;
+		return ctx.genTokLoader.load(objkt.metadata?.artifactUri);
+	}
+
+	@FieldResolver((returns) => String, {
+		description: "IPFS uri pointing to the 300x300 (contained) thumbnail",
+	})
+	thumbnailUri(@Root() objkt: Objkt, @Ctx() ctx: RequestContext) {
+		if (objkt.thumbnailUri) return objkt.thumbnailUri;
+		return ctx.genTokLoader.load(objkt.metadata?.thumbnailUri);
+	}
+
+	@FieldResolver((returns) => String, {
+		description: "IPFS uri pointing to the full res image",
+	})
+	displayUri(@Root() objkt: Objkt, @Ctx() ctx: RequestContext) {
+		if (objkt.displayUri) return objkt.displayUri;
+		return ctx.genTokLoader.load(objkt.metadata?.displayUri);
+	}
+
 	@FieldResolver(returns => [Split], {
 		description: "A list of the royalties split for this gentk."
 	})


### PR DESCRIPTION
This PR attempts to update `Objkt` to supply `artifactUri`, `thumbnailUri`, and `displayUri` outside of the `metadata` field. These are very common fields and nesting them only within `metadata` is problematic because it requires loading the entire `metadata` field to access them. Metadata can be huge for some `Objkt`s because it contains the description of the project and a lot of other data that is not necessarily always needed. 

I wasn't able to fully test this because I had issues getting the Docker container up and running:
https://github.com/fxhash/fxhash-api/issues/31
https://github.com/fxhash/fxhash-api/issues/27