### PR TITLE
Feat/collection offers

### DIFF
--- a/src/Entity/CollectionOffer.ts
+++ b/src/Entity/CollectionOffer.ts
@@ -1,0 +1,98 @@
+import { Field, ObjectType } from "type-graphql"
+import { Filter } from "type-graphql-filter"
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  BaseEntity,
+  ManyToOne,
+  Index,
+} from "typeorm"
+import { GenerativeToken } from "./GenerativeToken"
+import { User } from "./User"
+
+@Entity()
+@ObjectType({
+  description:
+    "Users can make offers on entire collections through the fxhash marketplace v2 contract.",
+})
+export class CollectionOffer extends BaseEntity {
+  @Field({
+    description:
+      "The ID of the collection offer, corresponds to the ID in the marketplace contract",
+  })
+  @PrimaryColumn()
+  id: number
+
+  @Field({
+    description:
+      "The version of the contract, for now all the offers are on the same contract (1)",
+  })
+  @PrimaryColumn()
+  version: number
+
+  @Index()
+  @ManyToOne(() => User, user => user.offers)
+  buyer: User
+
+  @Column()
+  buyerId: string
+
+  @Index()
+  @ManyToOne(() => GenerativeToken, token => token.collectionOffers)
+  token: GenerativeToken
+
+  @Column()
+  tokenId: number
+
+  @Field({
+    description: "The price proposed by the buyer",
+  })
+  @Column({ type: "bigint", default: "0" })
+  price: string
+
+  @Field({
+    description:
+      "The number of gentks the buyer wants to buy from the collection",
+  })
+  @Column()
+  amount: number
+
+  @Field({
+    description:
+      "The initial number of gentks the buyer wants to buy from the collection",
+  })
+  @Column()
+  initialAmount: number
+
+  @Field({
+    description:
+      "The block time when the collection offer was registerd on the blockchain",
+  })
+  @Column({ type: "timestamptz" })
+  createdAt: Date
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      "The block time when the collection offer was cancelled. If null, the offer was never cancelled. Completed collection offers cannot be cancelled.",
+  })
+  @Column({ type: "timestamptz", nullable: true })
+  cancelledAt: Date | null
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      "The block time when the collection offer was fulfilled. If null, the offer was never fulfilled. Completed collection offers cannot be cancelled.",
+  })
+  @Column({ type: "timestamptz", nullable: true })
+  completedAt: Date | null
+
+  //
+  // CUSTOM FILTERS
+  //
+
+  // is the collection offer active ?
+  @Filter(["eq"], () => Boolean)
+  active: boolean
+}

--- a/src/Entity/GenerativeToken.ts
+++ b/src/Entity/GenerativeToken.ts
@@ -21,6 +21,7 @@ import { Action } from "./Action"
 import { ArticleGenerativeToken } from "./ArticleGenerativeToken"
 import { Codex } from "./Codex"
 import { CodexUpdateRequest } from "./CodexUpdateRequest"
+import { CollectionOffer } from "./CollectionOffer"
 import { MarketStats } from "./MarketStats"
 import { MarketStatsHistory } from "./MarketStatsHistory"
 import { MediaImage } from "./MediaImage"
@@ -235,6 +236,9 @@ export class GenerativeToken extends BaseEntity {
 
   @OneToMany(() => Reserve, reserve => reserve.token)
   reserves: Reserve[]
+
+  @OneToMany(() => CollectionOffer, offer => offer.token)
+  collectionOffers: CollectionOffer[]
 
   @Field({
     description:

--- a/src/Query/Filters/Offer.ts
+++ b/src/Query/Filters/Offer.ts
@@ -2,32 +2,29 @@ import { Brackets } from "typeorm"
 import { OffersSortInput } from "../../Resolver/Arguments/Sort"
 import { TQueryFilter } from "./QueryFilter"
 
-
 type OfferFilters = Record<string, any>
 
 /**
  * Apllies filters and sort arguments to a query
  */
 export const offerQueryFilter: TQueryFilter<
-  OfferFilters, OffersSortInput
-> = async (
-  query,
-  filters,
-  sort,
-) => {
+  OfferFilters,
+  OffersSortInput
+> = async (query, filters, sort) => {
   // apply filters, if any
-	if (filters) {
-		if (filters.active_eq === true) {
-			query.andWhere("offer.cancelledAt is null")
-			query.andWhere("offer.acceptedAt is null")
-		}
-		else if (filters.active_eq === false) {
-			query.andWhere(new Brackets(qb => {
-				qb.where("offer.cancelledAt is not null")
-				qb.orWhere("offer.acceptedAt is not null")
-			}))
-		}
-	}
+  if (filters) {
+    if (filters.active_eq === true) {
+      query.andWhere("offer.cancelledAt is null")
+      query.andWhere("offer.acceptedAt is null")
+    } else if (filters.active_eq === false) {
+      query.andWhere(
+        new Brackets(qb => {
+          qb.where("offer.cancelledAt is not null")
+          qb.orWhere("offer.acceptedAt is not null")
+        })
+      )
+    }
+  }
 
   // add the sort arguments
   if (sort) {
@@ -37,4 +34,30 @@ export const offerQueryFilter: TQueryFilter<
   }
 
   return query
+}
+
+export const offerUnionQueryFilterRaw = (
+  filters: OfferFilters,
+  sort: OffersSortInput
+) => {
+  const where: string[] = []
+
+  if (filters.active_eq === true) {
+    where.push(
+      `"cancelledAt" is null AND "acceptedAt" is null AND "completedAt" is null`
+    )
+  } else if (filters.active_eq === false) {
+    where.push(
+      `"cancelledAt" is not null OR "acceptedAt" is not null OR "completedAt" is not null`
+    )
+  }
+
+  const orderBy = Object.keys(sort).map(
+    (key, index) => `"${key}" ${Object.values(sort)[index]}`
+  )
+
+  return {
+    where: where.length ? where.join(" AND ") : undefined,
+    orderBy: orderBy.length ? orderBy.join(", ") : undefined,
+  }
 }

--- a/src/Resolver/Collection.ts
+++ b/src/Resolver/Collection.ts
@@ -20,6 +20,7 @@ import { MintTicketResolver } from "./MintTicketResolver"
 import { MintTicketSettingsResolver } from "./MintTicketSettingsResolver"
 import { RedeemableResolver } from "./RedeemableResolver"
 import { RedemptionResolver } from "./RedemptionResolver"
+import { CollectionOfferResolver } from "./CollectionOfferResolver"
 
 export const ResolverCollection: NonEmptyArray<Function> = [
   UserResolver,
@@ -28,6 +29,7 @@ export const ResolverCollection: NonEmptyArray<Function> = [
   ActionResolver,
   ListingResolver,
   OfferResolver,
+  CollectionOfferResolver,
   MarketStatsDataResolver,
   MarketStatsResolver,
   SplitResolver,

--- a/src/Resolver/CollectionOfferResolver.ts
+++ b/src/Resolver/CollectionOfferResolver.ts
@@ -1,0 +1,26 @@
+import { Ctx, FieldResolver, Resolver, Root } from "type-graphql"
+import { User } from "../Entity/User"
+import { RequestContext } from "../types/RequestContext"
+import { CollectionOffer } from "../Entity/CollectionOffer"
+import { GenerativeToken } from "../Entity/GenerativeToken"
+
+@Resolver(CollectionOffer)
+export class CollectionOfferResolver {
+  @FieldResolver(returns => User, {
+    nullable: true,
+    description: "The user who's proposing the offer.",
+  })
+  buyer(@Root() offer: CollectionOffer, @Ctx() ctx: RequestContext) {
+    if (offer.buyer) return offer.buyer
+    return ctx.usersLoader.load(offer.buyerId)
+  }
+
+  @FieldResolver(returns => GenerativeToken, {
+    nullable: true,
+    description: "The token associated with the collection offer.",
+  })
+  async token(@Root() offer: CollectionOffer, @Ctx() ctx: RequestContext) {
+    if (offer.token) return offer.token
+    return ctx.genTokLoader.load(offer.tokenId)
+  }
+}

--- a/src/Resolver/UserResolver.ts
+++ b/src/Resolver/UserResolver.ts
@@ -2,21 +2,14 @@ import {
   Arg,
   Args,
   Ctx,
-  Field,
   FieldResolver,
-  Int,
-  ObjectType,
   Query,
   Resolver,
   Root,
 } from "type-graphql"
-import { Brackets, IsNull, Not } from "typeorm"
+import { Brackets, getManager } from "typeorm"
 import { Action, FiltersAction } from "../Entity/Action"
-import {
-  GenerativeFilters,
-  GenerativeToken,
-  GenTokFlag,
-} from "../Entity/GenerativeToken"
+import { GenerativeFilters, GenerativeToken } from "../Entity/GenerativeToken"
 import { FiltersObjkt, Objkt } from "../Entity/Objkt"
 import { Listing } from "../Entity/Listing"
 import { User, UserAuthorization, UserFilters, UserType } from "../Entity/User"
@@ -44,6 +37,12 @@ import { Article, ArticleFilters } from "../Entity/Article"
 import { ArticleLedger } from "../Entity/ArticleLedger"
 import { MediaImage } from "../Entity/MediaImage"
 import { MintTicket } from "../Entity/MintTicket"
+import {
+  AnyOffer,
+  collectionOfferUnionFields,
+  offerUnionFields,
+} from "../types/AnyOffer"
+import { offerUnionQueryFilterRaw } from "../Query/Filters/Offer"
 
 @Resolver(User)
 export class UserResolver {
@@ -279,6 +278,34 @@ export class UserResolver {
     })
   }
 
+  @FieldResolver(returns => [AnyOffer], {
+    description:
+      "Returns all the offers and collection offers made by the user. Can be filtered.",
+  })
+  async allOffersSent(
+    @Root() user: User,
+    @Arg("filters", FiltersOffer, { nullable: true }) filters: any,
+    @Arg("sort", { nullable: true }) sort: OffersSortInput
+  ) {
+    // default sort
+    if (!sort || Object.keys(sort).length === 0) {
+      sort = {
+        createdAt: "DESC",
+      }
+    }
+
+    // union not supported by typeorm - use raw query to get all offers
+    const { where, orderBy } = offerUnionQueryFilterRaw(filters, sort)
+    return getManager().query(`
+      SELECT * FROM (
+        SELECT ${offerUnionFields} FROM offer
+        UNION SELECT ${collectionOfferUnionFields} FROM collection_offer
+      ) as subq
+      WHERE "buyerId" = '${user.id}' ${where ? `AND (${where})` : ""}
+      ORDER BY ${orderBy}
+    `)
+  }
+
   @FieldResolver(returns => [Offer], {
     description:
       "Returns all the offers made by users on tokens owned by the given user.",
@@ -301,6 +328,50 @@ export class UserResolver {
       filters: filters,
       sort: sort,
     })
+  }
+
+  @FieldResolver(returns => [AnyOffer], {
+    description:
+      "Returns all the offers and collection offers received by the user. Can be filtered.",
+  })
+  async allOffersReceived(
+    @Root() user: User,
+    @Arg("filters", FiltersOffer, { nullable: true }) filters: any,
+    @Arg("sort", { nullable: true }) sort: OffersSortInput
+  ) {
+    // default sort
+    if (!sort || Object.keys(sort).length === 0) {
+      sort = {
+        createdAt: "DESC",
+      }
+    }
+
+    // get all offers on objkts owned by user
+    const receivedOfferIds = `
+      SELECT offer.id FROM offer JOIN objkt
+        ON offer."objktId" = objkt.id
+        AND objkt."issuerVersion" = offer."objktIssuerVersion"
+        WHERE objkt."ownerId" = '${user.id}'
+    `
+
+    // get all collection offers on objkts owned by user
+    const receivedCollectionOfferIds = `
+      SELECT DISTINCT collection_offer.id FROM collection_offer JOIN objkt
+        ON collection_offer."tokenId" = objkt."issuerId"
+        WHERE objkt."ownerId" = '${user.id}'
+    `
+
+    // union not supported by typeorm - use raw query to get all offers
+    const { where, orderBy } = offerUnionQueryFilterRaw(filters, sort)
+    return getManager().query(`
+      SELECT * FROM (
+        SELECT ${offerUnionFields} FROM offer WHERE offer.id IN (${receivedOfferIds})
+        UNION
+        SELECT ${collectionOfferUnionFields} FROM collection_offer WHERE collection_offer.id IN (${receivedCollectionOfferIds})
+      ) as subq
+      ${where ? `WHERE ${where}` : ""}
+      ORDER BY ${orderBy}
+    `)
   }
 
   @FieldResolver(returns => [User], {

--- a/src/types/AnyOffer.ts
+++ b/src/types/AnyOffer.ts
@@ -16,3 +16,48 @@ const AnyOffer = createUnionType({
     throw new Error("Could not resolve type for AnyOffer")
   },
 })
+
+// fields shared by offers & collection offers
+const commonFields = [
+  "id",
+  "version",
+  "createdAt",
+  "buyerId",
+  "price",
+  "cancelledAt",
+]
+
+// fields unique to offers
+const offerFields = ["acceptedAt", "objktId", "objktIssuerVersion"]
+
+// fields unique to collection offers
+const collectionOfferFields = [
+  "completedAt",
+  "amount",
+  "initialAmount",
+  "tokenId",
+]
+
+/**
+ * used to generate all fields for UNION of offers & collection offers
+ *
+ * uses `NULL as ${field}` for fields that are not present in the other type
+ * in the UNION so that the query result contains all fields, e.g. for offers:
+ *
+ * id, version, createdAt, ..., NULL as completedAt, NULL as amount, ...
+ */
+//
+
+const offerUnionFields = [
+  ...commonFields.map(field => `"${field}"`),
+  ...offerFields.map(field => `"${field}"`),
+  ...collectionOfferFields.map(field => `NULL as "${field}"`),
+].join(", ")
+
+const collectionOfferUnionFields = [
+  ...commonFields.map(field => `"${field}"`),
+  ...offerFields.map(field => `NULL as "${field}"`),
+  ...collectionOfferFields.map(field => `"${field}"`),
+].join(", ")
+
+export { AnyOffer, offerUnionFields, collectionOfferUnionFields }

--- a/src/types/AnyOffer.ts
+++ b/src/types/AnyOffer.ts
@@ -1,0 +1,18 @@
+import { createUnionType } from "type-graphql"
+import { CollectionOffer } from "../Entity/CollectionOffer"
+import { Offer } from "../Entity/Offer"
+
+const AnyOffer = createUnionType({
+  name: "AnyOffer",
+  description: "Any offer, either a collection offer or a single gentk offer",
+  types: () => [CollectionOffer, Offer],
+  resolveType: value => {
+    if ((value as CollectionOffer).tokenId !== null) {
+      return CollectionOffer
+    }
+    if ((value as Offer).objktId !== null) {
+      return Offer
+    }
+    throw new Error("Could not resolve type for AnyOffer")
+  },
+})


### PR DESCRIPTION
sort of an ugly solution relying on union with raw queries for now, but I'm aware that this is likely to change as we have the wrapped tez implementation in a few weeks

alternatives would be to run two db queries and then combine them in the correct sort order via js, or have separate gql queries for collectionOffers which are combined in the frontend - both also feel hacky?? so I think it's ok for the time being...