### PR TITLE
Feat/fix minted price lodaer

### DIFF
--- a/src/DataLoaders/Objkt.test.ts
+++ b/src/DataLoaders/Objkt.test.ts
@@ -24,7 +24,6 @@ import {
   createObjktRoyaltiesSplitsLoader,
   createObjktsLoader,
 } from "./Objkt"
-import { TokenActionType } from "../Entity/Action"
 import { ETransationType } from "../Entity/Transaction"
 
 let manager: EntityManager

--- a/src/DataLoaders/Objkt.test.ts
+++ b/src/DataLoaders/Objkt.test.ts
@@ -9,6 +9,7 @@ import {
   offerFactory,
   redeemableFactory,
   redemptionFactory,
+  transactionFactory,
 } from "../tests/factories"
 import { GenerativeTokenVersion } from "../types/GenerativeToken"
 import { createConnection } from "../createConnection"
@@ -24,6 +25,7 @@ import {
   createObjktsLoader,
 } from "./Objkt"
 import { TokenActionType } from "../Entity/Action"
+import { ETransationType } from "../Entity/Transaction"
 
 let manager: EntityManager
 let connection: Connection
@@ -39,6 +41,7 @@ afterAll(() => {
 })
 
 const cleanup = async () => {
+  await manager.query("DELETE FROM transaction")
   await manager.query("DELETE FROM redemption")
   await manager.query("DELETE FROM redeemable")
   await manager.query("DELETE FROM listing")
@@ -467,18 +470,16 @@ describe("Objkt dataloaders", () => {
       await objktFactory(0, GenerativeTokenVersion.V3, { tokenId: 0 })
       await objktFactory(1, GenerativeTokenVersion.V3, { tokenId: 1 })
 
-      // create some minted actions
-      await actionFactory({
+      // create some primary transactions
+      await transactionFactory(0, ETransationType.PRIMARY, {
         objktId: 0,
         objktIssuerVersion: GenerativeTokenVersion.PRE_V3,
-        type: TokenActionType.MINTED_FROM,
-        numericValue: 100,
+        price: "100",
       })
-      await actionFactory({
+      await transactionFactory(0, ETransationType.PRIMARY, {
         objktId: 1,
         objktIssuerVersion: GenerativeTokenVersion.V3,
-        type: TokenActionType.MINTED_FROM,
-        numericValue: 200,
+        price: "200",
       })
     })
 

--- a/src/DataLoaders/Objkt.ts
+++ b/src/DataLoaders/Objkt.ts
@@ -1,16 +1,14 @@
 import DataLoader from "dataloader"
-import { Brackets, In } from "typeorm"
 import { Action } from "../Entity/Action"
-import { GenerativeToken } from "../Entity/GenerativeToken"
 import { Listing } from "../Entity/Listing"
 import { Objkt } from "../Entity/Objkt"
 import { Offer } from "../Entity/Offer"
-import { Redeemable } from "../Entity/Redeemable"
 import { Redemption } from "../Entity/Redemption"
 import { Split } from "../Entity/Split"
 import { offerQueryFilter } from "../Query/Filters/Offer"
 import { ObjktId } from "../Scalar/ObjktId"
 import { matchesEntityObjktIdAndIssuerVersion } from "../Utils/Objkt"
+import { ETransationType, Transaction } from "../Entity/Transaction"
 
 /**
  * Given a list of objkt IDs, outputs a list of Objkt entities
@@ -186,27 +184,20 @@ export const createObjktAvailableRedeemablesLoader = () =>
  * Given a list of objkt IDs, outputs their minted price
  */
 const batchObjktMintedPriceLoader = async ids => {
-  const actions = await Action.createQueryBuilder("a")
-    .select([
-      "a.id",
-      "a.objktId",
-      "a.objktIssuerVersion",
-      "a.type",
-      "a.numericValue",
-    ])
-    .addSelect('min("createdAt")', "createdAt")
-    .where(matchesEntityObjktIdAndIssuerVersion(ids, "a"))
-    .andWhere("a.type = 'MINTED_FROM'")
-    .groupBy("a.id")
-    .addGroupBy('a."objktId"')
+  const transactions = await Transaction.createQueryBuilder("t")
+    .select()
+    .where(matchesEntityObjktIdAndIssuerVersion(ids, "t"))
+    .andWhere({
+      type: ETransationType.PRIMARY,
+    })
     .getMany()
 
   return ids.map(
     ({ id, issuerVersion }: ObjktId) =>
-      actions.find(
+      transactions.find(
         action =>
           action.objktId === id && action.objktIssuerVersion === issuerVersion
-      )?.numericValue
+      )?.price
   )
 }
 export const createObjktMintedPriceLoader = () =>

--- a/src/DataLoaders/User.test.ts
+++ b/src/DataLoaders/User.test.ts
@@ -34,6 +34,7 @@ afterAll(() => {
 })
 
 const cleanup = async () => {
+  await manager.query("DELETE FROM action")
   await manager.query("DELETE FROM collection_offer")
   await manager.query("DELETE FROM offer")
   await manager.query("DELETE FROM objkt")
@@ -41,7 +42,7 @@ const cleanup = async () => {
   await manager.query("DELETE FROM generative_token")
 }
 
-// afterEach(cleanup)
+afterEach(cleanup)
 
 describe("User dataloaders", () => {
   let dataloader
@@ -239,7 +240,7 @@ describe("User dataloaders", () => {
     })
   })
 
-  describe.only("createUsersOffersAndCollectionOffersReceivedLoader", () => {
+  describe("createUsersOffersAndCollectionOffersReceivedLoader", () => {
     beforeAll(async () => {
       dataloader = createUsersOffersAndCollectionOffersReceivedLoader()
 

--- a/src/Entity/Transaction.ts
+++ b/src/Entity/Transaction.ts
@@ -1,13 +1,20 @@
 import { ObjectType } from "type-graphql"
-import { BaseEntity, Column, Entity, Index, ManyToMany, ManyToOne, PrimaryGeneratedColumn } from "typeorm"
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm"
 import { Article } from "./Article"
 import { GenerativeToken } from "./GenerativeToken"
 import { Objkt } from "./Objkt"
-
+import { GenerativeTokenVersion } from "../types/GenerativeToken"
 
 export enum ETransationType {
-  PRIMARY       = "PRIMARY",
-  SECONDARY     = "SECONDARY",
+  PRIMARY = "PRIMARY",
+  SECONDARY = "SECONDARY",
 }
 
 /**
@@ -41,18 +48,25 @@ export class Transaction extends BaseEntity {
 
   @Index()
   @Column()
-  tokenId: number
-  
+  tokenId?: number
+
   @ManyToOne(() => Objkt, objkt => objkt.transactions)
   objkt: Objkt
-  
+
   @Index()
   @Column()
-  objktId: number
-  
+  objktId?: number
+
+  @Column({
+    type: "enum",
+    enumName: "generative_token_version",
+    enum: GenerativeTokenVersion,
+  })
+  objktIssuerVersion?: GenerativeTokenVersion
+
   @ManyToOne(() => Article, article => article.transactions)
   article: Article
-  
+
   @Index()
   @Column({ nullable: true })
   articleId: number

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -24,6 +24,7 @@ import { Split } from "../Entity/Split"
 import { User } from "../Entity/User"
 import { GenerativeTokenVersion } from "../types/GenerativeToken"
 import { CollectionOffer } from "../Entity/CollectionOffer"
+import { ETransationType, Transaction } from "../Entity/Transaction"
 
 export const generativeTokenFactory = async (
   id: number,
@@ -399,4 +400,22 @@ export const gentkAssignFactory = async (
   gentkAssign.gentkIssuerVersion = gentkIssuerVersion
   await gentkAssign.save()
   return gentkAssign
+}
+
+export const transactionFactory = async (
+  id: number,
+  type: ETransationType,
+  config: Partial<Transaction> = {}
+) => {
+  const transaction = new Transaction()
+  transaction.id = id
+  transaction.type = type
+  transaction.createdAt = config.createdAt || new Date()
+  transaction.opHash = config.opHash || "opHash"
+  transaction.tokenId = config.tokenId
+  transaction.objktId = config.objktId
+  transaction.objktIssuerVersion = config.objktIssuerVersion
+  transaction.price = config.price || "1000000"
+  await transaction.save()
+  return transaction
 }


### PR DESCRIPTION
we need to use primary transactions to obtain the correct minted price because gentks are decoupled from the primary transaction when minting via ticket 

the primary transaction will always have the correct minted price whether or not a ticket is used